### PR TITLE
Implement saving and editing of custom Quizzes in localStorage

### DIFF
--- a/Day-11-Quiz-App/app.js
+++ b/Day-11-Quiz-App/app.js
@@ -148,6 +148,7 @@ class Quiz {
           <div class="quiz-repeat">
             <button class="btn" id="restartQuizButton" style="text-align: center; background-color:#3399ff;">Take Quiz Again</button>
             <button class="btn" id="quitQuizButtonEnd" style="text-align: center; background-color:#3399ff;" >Quit</button>
+            <hr>
           </div>
         `;
         this.containerElement.innerHTML = quizEndHTML;

--- a/Day-11-Quiz-App/app.js
+++ b/Day-11-Quiz-App/app.js
@@ -148,7 +148,6 @@ class Quiz {
           <div class="quiz-repeat">
             <button class="btn" id="restartQuizButton" style="text-align: center; background-color:#3399ff;">Take Quiz Again</button>
             <button class="btn" id="quitQuizButtonEnd" style="text-align: center; background-color:#3399ff;" >Quit</button>
-            <hr>
           </div>
         `;
         this.containerElement.innerHTML = quizEndHTML;

--- a/Day-11-Quiz-App/index.html
+++ b/Day-11-Quiz-App/index.html
@@ -133,7 +133,7 @@
 
         const editQuizSelect = document.getElementById("editQuizSelect");
         const editQuizButton = document.getElementById("editQuizButton");
-        let confirmDeletion = true;
+
         editQuizButton.addEventListener("click", () => {
             const optionSelect = document.getElementById("optionSelect");
             if (editQuizSelect.value != optionSelect.value) {
@@ -144,23 +144,16 @@
                 new QuizBuilder(elementId, quizToEdit).start();
             } 
         })
-        const confirmDeletionFunction = () => {
-            const confirmDeletionAlert = confirm("Are you sure you want to delete the Quiz?");
-            if(confirmDeletionAlert === true) {
-                console.log("Nooo")
-                return confirmDeletion 
-            } else {
-                return !confirmDeletion
-            }
+        const promptUserToConfirmQuizDeletion = () => {
+            return confirm("Are you sure you want to delete the Quiz?");
         }
         const deleteQuizButton = document.getElementById("deleteQuizButton");
-        deleteQuizButton.addEventListener("click", (customQuizzes) => {
-            confirmDeletionFunction();
+        deleteQuizButton.addEventListener("click", () => {
+            const confirmDeletion = promptUserToConfirmQuizDeletion();
             if (confirmDeletion) {
-                console.log("Yes!")
-                let newArrayWithoutSelectedQuiz = customQuizzes.filter(customQuiz => customQuiz.title != editQuizSelect.value);
-                localStorage.removeItem("SidneyQuiz:custom");
+                const newArrayWithoutSelectedQuiz = getCustomQuizzesFromLocalStorage().filter(customQuiz => customQuiz.title !== editQuizSelect.value);
                 localStorage.setItem("SidneyQuiz:custom", JSON.stringify(newArrayWithoutSelectedQuiz));
+                displayCustomQuizButtonsFromLocalStorage(getCustomQuizzesFromLocalStorage());
             }
         })
 

--- a/Day-11-Quiz-App/index.html
+++ b/Day-11-Quiz-App/index.html
@@ -32,7 +32,8 @@
             <button class="btn" id="createQuizButton" style="text-align: center">Create Custom Quiz </button>
         <form>
             <select class="editQuiz" id="editQuizSelect"></select>
-            <input type="submit" class="editQuiz" id="editQuizButton" style="text-align: center; display: inline-block" value="Edit">
+            <input type="button" class="editQuiz" id="editQuizButton" style="text-align: center; display: inline-block" value="Edit">
+            <input type="button" class="editQuiz" id="deleteQuizButton" style="text-align: center; display: inline-block" value="Delete">
         </form>
             </div>
             <div id="sik-quiz"></div>
@@ -133,8 +134,10 @@
             const customQuizzesString = localStorage.getItem("SidneyQuiz:custom");
             const editQuizButton = document.getElementById("editQuizButton");
             const editQuizSelect = document.getElementById("editQuizSelect");
+            const deleteQuizButton = document.getElementById("deleteQuizButton");
 
             if (customQuizzesString) {
+                deleteQuizButton.style.display = "inline-block";
                 editQuizButton.style.display = "inline-block";
                 editQuizSelect.style.display = "inline-block";
                 const customQuizzes = JSON.parse(customQuizzesString);
@@ -157,6 +160,7 @@
                 })      
             } else {
                 editQuizSelect.style.display = "none";
+                deleteQuizButton.style.display = "none";
                 editQuizButton.style.display = "none";
             }
         }

--- a/Day-11-Quiz-App/index.html
+++ b/Day-11-Quiz-App/index.html
@@ -128,8 +128,8 @@
             displayCustomQuizElements();
         });
 
-        const displayCustomQuizElements = () => {
-            displayCustomQuizButtons(getCustomQuizzesFromLocalStorage()); // displays custom quiz buttons on initial page load
+        function displayCustomQuizElements() {
+            displayCustomQuizButtons(getCustomQuizzesFromLocalStorage());
             displaySelectForEditingAndDeletingCustomQuizzes(getCustomQuizzesFromLocalStorage());
         }
 

--- a/Day-11-Quiz-App/index.html
+++ b/Day-11-Quiz-App/index.html
@@ -30,8 +30,10 @@
                 <hr>
             <div id="customQuizButtonListContainer"></div>
             <button class="btn" id="createQuizButton" style="text-align: center">Create Custom Quiz </button>
+        <form>
             <select class="editQuiz" id="editQuizSelect"></select>
-            <button class="editQuiz" id="editQuizButton" style="text-align: center; display: inline-block">Edit</button>
+            <input type="submit" class="editQuiz" id="editQuizButton" style="text-align: center; display: inline-block" value="Edit">
+        </form>
             </div>
             <div id="sik-quiz"></div>
             <footer>
@@ -129,7 +131,11 @@
             const customQuizButtonContainer = document.getElementById("customQuizButtonListContainer");
             customQuizButtonContainer.textContent = '';
             const customQuizzesString = localStorage.getItem("SidneyQuiz:custom");
+            const editQuizButton = document.getElementById("editQuizButton");
+            const editQuizSelect = document.getElementById("editQuizSelect");
+
             if (customQuizzesString) {
+                editQuizButton.style.display = "inline-block";
                 editQuizSelect.style.display = "inline-block";
                 const customQuizzes = JSON.parse(customQuizzesString);
                 customQuizzes.forEach((customQuiz) => {
@@ -141,15 +147,17 @@
                         new Quiz(JSON.stringify(customQuiz.questions), elementId, `${customQuiz.title}`).start()
                     });
 
-                    const editQuizSelect = document.getElementById("editQuizSelect");
+                    
                     const editQuizOption = document.createElement("option");
 
                     // TODO: set the value of the option element
                     editQuizSelect.appendChild(editQuizOption);
+                    editQuizOption.value = customQuiz.title
+                    editQuizOption.textContent = `Quiz: ${customQuiz.title}`;
                 })      
             } else {
-                const editQuizSelect = document.getElementById("editQuizSelect");
                 editQuizSelect.style.display = "none";
+                editQuizButton.style.display = "none";
             }
         }
         

--- a/Day-11-Quiz-App/index.html
+++ b/Day-11-Quiz-App/index.html
@@ -28,13 +28,13 @@
             <div id="customQuizContainer">
                 <h2>Custom Quizzes (Work in progress)</h2>
                 <hr>
-            <div id="customQuizButtonListContainer"></div>
-            <button class="btn" id="createQuizButton" style="text-align: center">Create Custom Quiz </button>
-        <form>
-            <select class="editQuiz" id="editQuizSelect"></select>
-            <input type="button" class="editQuiz" id="editQuizButton" style="text-align: center; display: inline-block" value="Edit">
-            <input type="button" class="editQuiz" id="deleteQuizButton" style="text-align: center; display: inline-block" value="Delete">
-        </form>
+                <div id="customQuizButtonListContainer"></div>
+                <button class="btn" id="createQuizButton" style="text-align: center">Create Custom Quiz</button>
+                <div>
+                    <select class="editQuiz" id="editQuizSelect"></select>
+                    <input type="button" class="editQuiz" id="editQuizButton" style="text-align: center; display: inline-block" value="Edit">
+                    <input type="button" class="editQuiz" id="deleteQuizButton" style="text-align: center; display: inline-block" value="Delete">
+                </div>
             </div>
             <div id="sik-quiz"></div>
             <footer>

--- a/Day-11-Quiz-App/index.html
+++ b/Day-11-Quiz-App/index.html
@@ -125,11 +125,15 @@
             quizChooser.style.display = "block";
             customQuizContainer.style.display = "block";
             // TODO: implement dedicated QuizBuilder:save event, as we do not need to rebuild the buttons if no quiz was created.
-            displayCustomQuizButtons(getCustomQuizzesFromLocalStorage()); // reloads custom quiz buttons
-            displaySelectForEditingAndDeletingCustomQuizzes(getCustomQuizzesFromLocalStorage());
+            displayCustomQuizElements();
         });
-        displayCustomQuizButtons(getCustomQuizzesFromLocalStorage()); // displays custom quiz buttons on initial page load
-        displaySelectForEditingAndDeletingCustomQuizzes(getCustomQuizzesFromLocalStorage());
+
+        const displayCustomQuizElements = () => {
+            displayCustomQuizButtons(getCustomQuizzesFromLocalStorage()); // displays custom quiz buttons on initial page load
+            displaySelectForEditingAndDeletingCustomQuizzes(getCustomQuizzesFromLocalStorage());
+        }
+
+        displayCustomQuizElements();
 
         const editQuizSelect = document.getElementById("editQuizSelect");
         const editQuizButton = document.getElementById("editQuizButton");
@@ -152,8 +156,7 @@
             if (confirmDeletion) {
                 const newArrayWithoutSelectedQuiz = getCustomQuizzesFromLocalStorage().filter(customQuiz => customQuiz.title !== editQuizSelect.value);
                 localStorage.setItem("SidneyQuiz:custom", JSON.stringify(newArrayWithoutSelectedQuiz));
-                displayCustomQuizButtons(getCustomQuizzesFromLocalStorage());
-                displaySelectForEditingAndDeletingCustomQuizzes(getCustomQuizzesFromLocalStorage());
+                displayCustomQuizElements();
             }
         })
 

--- a/Day-11-Quiz-App/index.html
+++ b/Day-11-Quiz-App/index.html
@@ -128,6 +128,18 @@
         });
         displayCustomQuizButtonsFromLocalStorage(); // displays custom quiz buttons on initial page load
 
+        const editQuizSelect = document.getElementById("editQuizSelect");
+        const editQuizButton = document.getElementById("editQuizButton");
+        const confirmDeletion = true;
+        editQuizButton.addEventListener("click", () => {
+            console.log(editQuizSelect.value)
+            console.log(this.customQuizzes);
+            if (confirmDeletion) {
+                let deletionArray = this.customQuizzes.filter()
+            }
+        })
+       
+
         function displayCustomQuizButtonsFromLocalStorage() {
             const customQuizButtonContainer = document.getElementById("customQuizButtonListContainer");
             customQuizButtonContainer.textContent = '';
@@ -135,13 +147,14 @@
             const editQuizButton = document.getElementById("editQuizButton");
             const editQuizSelect = document.getElementById("editQuizSelect");
             const deleteQuizButton = document.getElementById("deleteQuizButton");
-
+            
+        
             if (customQuizzesString) {
                 deleteQuizButton.style.display = "inline-block";
                 editQuizButton.style.display = "inline-block";
                 editQuizSelect.style.display = "inline-block";
-                const customQuizzes = JSON.parse(customQuizzesString);
-                customQuizzes.forEach((customQuiz) => {
+                this.customQuizzes = JSON.parse(customQuizzesString);
+                this.customQuizzes.forEach((customQuiz) => {
                     const button = document.createElement("button");
                     button.className = "btn customQuizButton"
                     customQuizButtonContainer.appendChild(button)
@@ -151,9 +164,8 @@
                     });
 
                     
-                    const editQuizOption = document.createElement("option");
+                    editQuizOption = document.createElement("option");
 
-                    // TODO: set the value of the option element
                     editQuizSelect.appendChild(editQuizOption);
                     editQuizOption.value = customQuiz.title
                     editQuizOption.textContent = `Quiz: ${customQuiz.title}`;
@@ -164,7 +176,15 @@
                 editQuizButton.style.display = "none";
             }
         }
-        
+
+//             editQuizButton.addEventListener("click", () => {
+//             if (confirm("Are you sure you want to delete the Quiz?")) {
+//     console.log("Yeah!")
+//     return confirmDeletion
+// } else {
+//             console.log("NO!")
+//             return !confirmDeletion
+//             }
     </script>
 </body>
 

--- a/Day-11-Quiz-App/index.html
+++ b/Day-11-Quiz-App/index.html
@@ -28,7 +28,10 @@
             <div id="customQuizContainer">
                 <h2>Custom Quizzes (Work in progress)</h2>
                 <hr>
-                <button class="btn" id="createQuizButton" style="text-align: center">Create Custom Quiz </button>
+            <div id="customQuizButtonListContainer"></div>
+            <button class="btn" id="createQuizButton" style="text-align: center">Create Custom Quiz </button>
+            <select class="editQuiz" id="editQuizSelect"></select>
+            <button class="editQuiz" id="editQuizButton" style="text-align: center; display: inline-block">Edit</button>
             </div>
             <div id="sik-quiz"></div>
             <footer>
@@ -59,7 +62,7 @@
                 "Apart from <b> tag, what other tag makes text bold ?", ["<fat>", "<black>", "<strong>", "<emp>"], "<strong>"
             )
         ];
-
+        
         const sportQuestions = [
         new Question(
                 "How many times has Roger Federer won Wimbledon playing singles?", ["7", "10", "8", "5"], "8"
@@ -114,11 +117,41 @@
 
         });
         quizElement.addEventListener("QuizBuilder:quit", () => {
+            // TODO: pass data of quiz that was just saved along in event, so that we only need to add one more button for the new quiz instead of rebuilding all buttons.
             quizChooser.style.display = "block";
             customQuizContainer.style.display = "block";
+            // TODO: implement dedicated QuizBuilder:save event, as we do not need to rebuild the buttons if no quiz was created.
+            displayCustomQuizButtonsFromLocalStorage(); // reloads custom quiz buttons
         });
+        displayCustomQuizButtonsFromLocalStorage(); // displays custom quiz buttons on initial page load
 
+        function displayCustomQuizButtonsFromLocalStorage() {
+            const customQuizButtonContainer = document.getElementById("customQuizButtonListContainer");
+            customQuizButtonContainer.textContent = '';
+            const customQuizzesString = localStorage.getItem("SidneyQuiz:custom");
+            if (customQuizzesString) {
+                editQuizSelect.style.display = "inline-block";
+                const customQuizzes = JSON.parse(customQuizzesString);
+                customQuizzes.forEach((customQuiz) => {
+                    const button = document.createElement("button");
+                    button.className = "btn customQuizButton"
+                    customQuizButtonContainer.appendChild(button)
+                    button.textContent = `Quiz: ${customQuiz.title}`;
+                    button.addEventListener("click", () => {
+                        new Quiz(JSON.stringify(customQuiz.questions), elementId, `${customQuiz.title}`).start()
+                    });
 
+                    const editQuizSelect = document.getElementById("editQuizSelect");
+                    const editQuizOption = document.createElement("option");
+
+                    // TODO: set the value of the option element
+                    editQuizSelect.appendChild(editQuizOption);
+                })      
+            } else {
+                const editQuizSelect = document.getElementById("editQuizSelect");
+                editQuizSelect.style.display = "none";
+            }
+        }
         
     </script>
 </body>

--- a/Day-11-Quiz-App/index.html
+++ b/Day-11-Quiz-App/index.html
@@ -119,42 +119,59 @@
             customQuizContainer.style.display = "none";
 
         });
+
         quizElement.addEventListener("QuizBuilder:quit", () => {
             // TODO: pass data of quiz that was just saved along in event, so that we only need to add one more button for the new quiz instead of rebuilding all buttons.
             quizChooser.style.display = "block";
             customQuizContainer.style.display = "block";
             // TODO: implement dedicated QuizBuilder:save event, as we do not need to rebuild the buttons if no quiz was created.
-            displayCustomQuizButtonsFromLocalStorage(); // reloads custom quiz buttons
+            displayCustomQuizButtonsFromLocalStorage(getCustomQuizzesFromLocalStorage()); // reloads custom quiz buttons
         });
-        displayCustomQuizButtonsFromLocalStorage(); // displays custom quiz buttons on initial page load
+        displayCustomQuizButtonsFromLocalStorage(getCustomQuizzesFromLocalStorage()); // displays custom quiz buttons on initial page load
 
         const editQuizSelect = document.getElementById("editQuizSelect");
         const editQuizButton = document.getElementById("editQuizButton");
-        const confirmDeletion = true;
+        let confirmDeletion = true;
         editQuizButton.addEventListener("click", () => {
-            console.log(editQuizSelect.value)
-            console.log(this.customQuizzes);
+            // TODO: Validate that editQuizSelect actually has a value before doing anything
+            const titleOfQuizToEdit = editQuizSelect.value;
+            const quizLocalStorageString = localStorage.getItem("SidneyQuiz:custom")
+            const parsedQuizzes = JSON.parse(quizLocalStorageString);
+            const quizToEdit = parsedQuizzes.find(quiz => titleOfQuizToEdit === quiz.title);
+            new QuizBuilder(elementId, quizToEdit).start();
+        })
+        const confirmDeletionFunction = () => {
+            const confirmDeletionAlert = confirm("Are you sure you want to delete the Quiz?");
+            if(confirmDeletionAlert === true) {
+                console.log("Nooo")
+                return confirmDeletion 
+            } else {
+                return !confirmDeletion
+            }
+        }
+        const deleteQuizButton = document.getElementById("deleteQuizButton");
+        deleteQuizButton.addEventListener("click", () => {
+            confirmDeletionFunction();
             if (confirmDeletion) {
-                let deletionArray = this.customQuizzes.filter()
+                console.log("Yes!")
+                let newArrayWithoutSelectedQuiz = customQuizzes.filter(customQuiz => customQuiz.title != editQuizSelect.value);
+                localStorage.removeItem("SidneyQuiz:custom");
+                localStorage.setItem("SidneyQuiz:custom", JSON.stringify(newArrayWithoutSelectedQuiz));
             }
         })
-       
 
-        function displayCustomQuizButtonsFromLocalStorage() {
+        function displayCustomQuizButtonsFromLocalStorage(customQuizzes) {
             const customQuizButtonContainer = document.getElementById("customQuizButtonListContainer");
             customQuizButtonContainer.textContent = '';
-            const customQuizzesString = localStorage.getItem("SidneyQuiz:custom");
             const editQuizButton = document.getElementById("editQuizButton");
             const editQuizSelect = document.getElementById("editQuizSelect");
             const deleteQuizButton = document.getElementById("deleteQuizButton");
-            
         
-            if (customQuizzesString) {
+            if (customQuizzes) {
                 deleteQuizButton.style.display = "inline-block";
                 editQuizButton.style.display = "inline-block";
                 editQuizSelect.style.display = "inline-block";
-                this.customQuizzes = JSON.parse(customQuizzesString);
-                this.customQuizzes.forEach((customQuiz) => {
+                customQuizzes.forEach((customQuiz) => {
                     const button = document.createElement("button");
                     button.className = "btn customQuizButton"
                     customQuizButtonContainer.appendChild(button)
@@ -177,14 +194,10 @@
             }
         }
 
-//             editQuizButton.addEventListener("click", () => {
-//             if (confirm("Are you sure you want to delete the Quiz?")) {
-//     console.log("Yeah!")
-//     return confirmDeletion
-// } else {
-//             console.log("NO!")
-//             return !confirmDeletion
-//             }
+        function getCustomQuizzesFromLocalStorage() {
+            const customQuizzesString = localStorage.getItem("SidneyQuiz:custom");
+            return customQuizzesString ? JSON.parse(customQuizzesString) : undefined;
+        }
     </script>
 </body>
 

--- a/Day-11-Quiz-App/index.html
+++ b/Day-11-Quiz-App/index.html
@@ -31,9 +31,7 @@
             <div id="customQuizButtonListContainer"></div>
             <button class="btn" id="createQuizButton" style="text-align: center">Create Custom Quiz </button>
         <form>
-            <select class="editQuiz" id="editQuizSelect">
-                <option id="optionSelect" disabled selected value> - select quiz - </option>
-            </select>
+            <select class="editQuiz" id="editQuizSelect"></select>
             <input type="button" class="editQuiz" id="editQuizButton" style="text-align: center; display: inline-block" value="Edit">
             <input type="button" class="editQuiz" id="deleteQuizButton" style="text-align: center; display: inline-block" value="Delete">
         </form>
@@ -127,16 +125,17 @@
             quizChooser.style.display = "block";
             customQuizContainer.style.display = "block";
             // TODO: implement dedicated QuizBuilder:save event, as we do not need to rebuild the buttons if no quiz was created.
-            displayCustomQuizButtonsFromLocalStorage(getCustomQuizzesFromLocalStorage()); // reloads custom quiz buttons
+            displayCustomQuizButtons(getCustomQuizzesFromLocalStorage()); // reloads custom quiz buttons
+            displaySelectForEditingAndDeletingCustomQuizzes(getCustomQuizzesFromLocalStorage());
         });
-        displayCustomQuizButtonsFromLocalStorage(getCustomQuizzesFromLocalStorage()); // displays custom quiz buttons on initial page load
+        displayCustomQuizButtons(getCustomQuizzesFromLocalStorage()); // displays custom quiz buttons on initial page load
+        displaySelectForEditingAndDeletingCustomQuizzes(getCustomQuizzesFromLocalStorage());
 
         const editQuizSelect = document.getElementById("editQuizSelect");
         const editQuizButton = document.getElementById("editQuizButton");
 
         editQuizButton.addEventListener("click", () => {
-            const optionSelect = document.getElementById("optionSelect");
-            if (editQuizSelect.value != optionSelect.value) {
+            if (editQuizSelect.value) {
                 const titleOfQuizToEdit = editQuizSelect.value;
                 const quizLocalStorageString = localStorage.getItem("SidneyQuiz:custom")
                 const parsedQuizzes = JSON.parse(quizLocalStorageString);
@@ -153,21 +152,16 @@
             if (confirmDeletion) {
                 const newArrayWithoutSelectedQuiz = getCustomQuizzesFromLocalStorage().filter(customQuiz => customQuiz.title !== editQuizSelect.value);
                 localStorage.setItem("SidneyQuiz:custom", JSON.stringify(newArrayWithoutSelectedQuiz));
-                displayCustomQuizButtonsFromLocalStorage(getCustomQuizzesFromLocalStorage());
+                displayCustomQuizButtons(getCustomQuizzesFromLocalStorage());
+                displaySelectForEditingAndDeletingCustomQuizzes(getCustomQuizzesFromLocalStorage());
             }
         })
 
-        function displayCustomQuizButtonsFromLocalStorage(customQuizzes) {
+        function displayCustomQuizButtons(customQuizzes) {
             const customQuizButtonContainer = document.getElementById("customQuizButtonListContainer");
-            customQuizButtonContainer.textContent = '';
-            const editQuizButton = document.getElementById("editQuizButton");
-            const editQuizSelect = document.getElementById("editQuizSelect");
-            const deleteQuizButton = document.getElementById("deleteQuizButton");
-        
-            if (customQuizzes) {
-                deleteQuizButton.style.display = "inline-block";
-                editQuizButton.style.display = "inline-block";
-                editQuizSelect.style.display = "inline-block";
+            customQuizButtonContainer.textContent = ''; // remove any buttons that were inside the container before.
+
+            if (customQuizzes && customQuizzes.length > 0) {
                 customQuizzes.forEach((customQuiz) => {
                     const button = document.createElement("button");
                     button.className = "btn customQuizButton"
@@ -176,10 +170,24 @@
                     button.addEventListener("click", () => {
                         new Quiz(JSON.stringify(customQuiz.questions), elementId, `${customQuiz.title}`).start()
                     });
+                })
+            }
+        }
 
-                    
+        function displaySelectForEditingAndDeletingCustomQuizzes(customQuizzes) {
+            const editQuizButton = document.getElementById("editQuizButton");
+            const editQuizSelect = document.getElementById("editQuizSelect");
+            const deleteQuizButton = document.getElementById("deleteQuizButton");
+            const firstEmptyOption = '<option disabled selected value> - select quiz - </option>'; // reset single select options
+            editQuizSelect.innerHTML = firstEmptyOption;
+        
+            if (customQuizzes && customQuizzes.length > 0) {
+                deleteQuizButton.style.display = "inline-block";
+                editQuizButton.style.display = "inline-block";
+                editQuizSelect.style.display = "inline-block";
+
+                customQuizzes.forEach((customQuiz) => {
                     editQuizOption = document.createElement("option");
-
                     editQuizSelect.appendChild(editQuizOption);
                     editQuizOption.value = customQuiz.title
                     editQuizOption.textContent = `Quiz: ${customQuiz.title}`;

--- a/Day-11-Quiz-App/index.html
+++ b/Day-11-Quiz-App/index.html
@@ -31,7 +31,9 @@
             <div id="customQuizButtonListContainer"></div>
             <button class="btn" id="createQuizButton" style="text-align: center">Create Custom Quiz </button>
         <form>
-            <select class="editQuiz" id="editQuizSelect"></select>
+            <select class="editQuiz" id="editQuizSelect">
+                <option id="optionSelect" disabled selected value> - select quiz - </option>
+            </select>
             <input type="button" class="editQuiz" id="editQuizButton" style="text-align: center; display: inline-block" value="Edit">
             <input type="button" class="editQuiz" id="deleteQuizButton" style="text-align: center; display: inline-block" value="Delete">
         </form>
@@ -133,12 +135,14 @@
         const editQuizButton = document.getElementById("editQuizButton");
         let confirmDeletion = true;
         editQuizButton.addEventListener("click", () => {
-            // TODO: Validate that editQuizSelect actually has a value before doing anything
-            const titleOfQuizToEdit = editQuizSelect.value;
-            const quizLocalStorageString = localStorage.getItem("SidneyQuiz:custom")
-            const parsedQuizzes = JSON.parse(quizLocalStorageString);
-            const quizToEdit = parsedQuizzes.find(quiz => titleOfQuizToEdit === quiz.title);
-            new QuizBuilder(elementId, quizToEdit).start();
+            const optionSelect = document.getElementById("optionSelect");
+            if (editQuizSelect.value != optionSelect.value) {
+                const titleOfQuizToEdit = editQuizSelect.value;
+                const quizLocalStorageString = localStorage.getItem("SidneyQuiz:custom")
+                const parsedQuizzes = JSON.parse(quizLocalStorageString);
+                const quizToEdit = parsedQuizzes.find(quiz => titleOfQuizToEdit === quiz.title);
+                new QuizBuilder(elementId, quizToEdit).start();
+            } 
         })
         const confirmDeletionFunction = () => {
             const confirmDeletionAlert = confirm("Are you sure you want to delete the Quiz?");
@@ -150,7 +154,7 @@
             }
         }
         const deleteQuizButton = document.getElementById("deleteQuizButton");
-        deleteQuizButton.addEventListener("click", () => {
+        deleteQuizButton.addEventListener("click", (customQuizzes) => {
             confirmDeletionFunction();
             if (confirmDeletion) {
                 console.log("Yes!")

--- a/Day-11-Quiz-App/index.html
+++ b/Day-11-Quiz-App/index.html
@@ -139,19 +139,24 @@
         const editQuizButton = document.getElementById("editQuizButton");
 
         editQuizButton.addEventListener("click", () => {
-            if (editQuizSelect.value) {
-                const titleOfQuizToEdit = editQuizSelect.value;
-                const quizLocalStorageString = localStorage.getItem("SidneyQuiz:custom")
-                const parsedQuizzes = JSON.parse(quizLocalStorageString);
-                const quizToEdit = parsedQuizzes.find(quiz => titleOfQuizToEdit === quiz.title);
-                new QuizBuilder(elementId, quizToEdit).start();
-            } 
+            if (!editQuizSelect.value) {
+                return; // Do nothing if no quiz is selected
+            }
+
+            const titleOfQuizToEdit = editQuizSelect.value;
+            const quizLocalStorageString = localStorage.getItem("SidneyQuiz:custom")
+            const parsedQuizzes = JSON.parse(quizLocalStorageString);
+            const quizToEdit = parsedQuizzes.find(quiz => titleOfQuizToEdit === quiz.title);
+            new QuizBuilder(elementId, quizToEdit).start();
         })
         const promptUserToConfirmQuizDeletion = () => {
             return confirm("Are you sure you want to delete the Quiz?");
         }
         const deleteQuizButton = document.getElementById("deleteQuizButton");
         deleteQuizButton.addEventListener("click", () => {
+            if (!editQuizSelect.value) {
+                return; // Do nothing if no quiz is selected
+            }
             const confirmDeletion = promptUserToConfirmQuizDeletion();
             if (confirmDeletion) {
                 const newArrayWithoutSelectedQuiz = getCustomQuizzesFromLocalStorage().filter(customQuiz => customQuiz.title !== editQuizSelect.value);

--- a/Day-11-Quiz-App/quizBuilder.js
+++ b/Day-11-Quiz-App/quizBuilder.js
@@ -40,6 +40,7 @@ class QuizBuilder {
         button.onclick = () => this.quit();
         const startEvent = new Event("QuizBuilder:start");
         this.containerElement.dispatchEvent(startEvent);
+        this._registerFormSubmitListener();
         this._registerAddQuestionButtonListener();
         if (this.questionsContainerMaxHeight) {
             this._addOverflowStylesToQuestionContainer();
@@ -55,6 +56,13 @@ class QuizBuilder {
         })
     }
 
+    _registerFormSubmitListener() {
+        const form = this.containerElement.getElementsByTagName("form")[0];
+        form.addEventListener("submit", (event) => {
+            event.preventDefault();
+            this.save();
+        }) 
+    }
 
     _registerAddQuestionButtonListener() {
         this.addQuestionButton.addEventListener("click", () => {

--- a/Day-11-Quiz-App/quizBuilder.js
+++ b/Day-11-Quiz-App/quizBuilder.js
@@ -17,12 +17,12 @@ class QuizBuilder {
                 <input id="quizTitle" class="inputStyles questionTitle" placeholder = "Type in a quiz name..." required></input>
             </div>
             <h2>Questions</h2>
-            <hr id="firstHRaboveDeleteDisplay">
+            <hr>
             <div id="questionsContainer">
             </div>
             <div>
                 <button type="button" id="${this._addQuestionButtonId}">+ Add Question</button>
-            </div>  
+            </div>
         <hr>
         <button type="submit" class="btn" id="${this._saveQuizButtonId}" style="text-align: center; background-color:#3399ff;">Save</button>
         </form>
@@ -100,8 +100,8 @@ class QuizBuilder {
     }
 
     addQuestion() {
-        this.newHR = document.createElement("hr");
-        this.questionsContainer.appendChild(this.newHR);
+        const newHR = document.createElement("hr");
+        this.questionsContainer.appendChild(newHR);
         this._addInputElementsForOneQuestion()
     }
 
@@ -128,7 +128,6 @@ class QuizBuilder {
     _addInputElementsForOneQuestion(questionData) {
         this.questionsContainer = document.getElementById("questionsContainer");
 
-        const removeQuestionButton = document.createElement("button");
         const questionText = document.createElement("input");
         const choices = document.createElement("input");
         const answer = document.createElement("input");
@@ -150,7 +149,6 @@ class QuizBuilder {
         const choicesHeader = document.createElement("text");
         const answerHeader = document.createElement("text");
 
-        this.questionsContainer.appendChild(removeQuestionButton);
         this.questionsContainer.appendChild(questionTextHeader);
         this.questionsContainer.appendChild(questionText);
         this.questionsContainer.appendChild(choicesHeader);
@@ -158,25 +156,6 @@ class QuizBuilder {
         this.questionsContainer.appendChild(answerHeader);
         this.questionsContainer.appendChild(answer);
         this.questionsContainer.appendChild(error);
-
-
-        // Shows removeQuestionButton 
-        removeQuestionButton.textContent = "Remove Questions";
-        removeQuestionButton.className = "removeQuestionButton";
-        choicesHeader.style.display = "inline-block";
-
-        removeQuestionButton.addEventListener("click", (event) => {
-            event.preventDefault();
-            removeQuestionButton.remove();
-            questionTextHeader.remove();
-            questionText.remove();
-            choicesHeader.remove();
-            choices.remove();
-            answerHeader.remove();
-            answer.remove();
-            error.remove();
-            this.newHR.remove();
-        })
         
         questionTextHeader.textContent = "Type in a question:";
         choicesHeader.textContent = "Type in the choices (comma separated): ";

--- a/Day-11-Quiz-App/quizBuilder.js
+++ b/Day-11-Quiz-App/quizBuilder.js
@@ -11,7 +11,7 @@ class QuizBuilder {
     _quizBuilderHTMLBody() {
         return `
         <h1>Quiz Builder</h1>
-        <form id="formID">
+        <form>
             <div>
                 <h2 id="quizNameHeader"> Enter a Quiz Name:</h2>
                 <input id="quizTitle" class="inputStyles questionTitle" placeholder = "Type in a quiz name..." required></input>
@@ -40,19 +40,11 @@ class QuizBuilder {
         button.onclick = () => this.quit();
         const startEvent = new Event("QuizBuilder:start");
         this.containerElement.dispatchEvent(startEvent);
-        this._registerFormSubmitListener();
         this._registerAddQuestionButtonListener();
         if (this.questionsContainerMaxHeight) {
             this._addOverflowStylesToQuestionContainer();
         }
         this._registerSubmitFromSelect();
-        const form = document.getElementById("formID");
-        // Disable enter to fix deleting question bug
-        form.addEventListener("keypress", function(event) {
-            if (event.key === "Enter") {
-              event.preventDefault();
-            }
-        });
     }
 
     _registerSubmitFromSelect() {
@@ -63,13 +55,6 @@ class QuizBuilder {
         })
     }
 
-    _registerFormSubmitListener() {
-        const form = this.containerElement.getElementsByTagName("form")[0];
-        form.addEventListener("submit", (event) => {
-            event.preventDefault();
-            this.save();
-        }) 
-    }
 
     _registerAddQuestionButtonListener() {
         this.addQuestionButton.addEventListener("click", () => {

--- a/Day-11-Quiz-App/quizBuilder.js
+++ b/Day-11-Quiz-App/quizBuilder.js
@@ -58,10 +58,8 @@ class QuizBuilder {
     _registerSubmitFromSelect() {
         const button = document.getElementById("editQuizButton");
         this.editQuizSelect = document.getElementById("editQuizSelect")
-        console.log(editQuizSelect.value)
         button.addEventListener("submit", (event) => {
             event.preventDefault();
-            console.log(editQuizSelect.value);
         })
     }
 

--- a/Day-11-Quiz-App/quizBuilder.js
+++ b/Day-11-Quiz-App/quizBuilder.js
@@ -10,7 +10,7 @@ class QuizBuilder {
     _quizBuilderHTMLBody() {
         return `
         <h1>Quiz Builder</h1>
-        <form>
+        <form id="formID">
             <div>
                 <h2 id="quizNameHeader"> Enter a Quiz Name:</h2>
                 <input id="quizTitle" class="inputStyles questionTitle" placeholder = "Type in a quiz name..." required></input>
@@ -45,6 +45,13 @@ class QuizBuilder {
             this._addOverflowStylesToQuestionContainer();
         }
         this._registerSubmitFromSelect();
+        const form = document.getElementById("formID");
+        // Disable enter to fix deleting question bug
+        form.addEventListener("keypress", function(event) {
+            if (event.key === "Enter") {
+              event.preventDefault();
+            }
+        });
     }
 
     _registerSubmitFromSelect() {

--- a/Day-11-Quiz-App/quizBuilder.js
+++ b/Day-11-Quiz-App/quizBuilder.js
@@ -15,8 +15,8 @@ class QuizBuilder {
                 <h2 id="quizNameHeader"> Enter a Quiz Name:</h2>
                 <input id="quizTitle" class="inputStyles questionTitle" placeholder = "Type in a quiz name..." required></input>
             </div>
-            <hr>
             <h2>Questions</h2>
+            <hr id="firstHRaboveDeleteDisplay">
             <div id="questionsContainer">
             </div>
             <div>

--- a/Day-11-Quiz-App/quizBuilder.js
+++ b/Day-11-Quiz-App/quizBuilder.js
@@ -17,12 +17,11 @@ class QuizBuilder {
             </div>
             <hr>
             <h2>Questions</h2>
-            <hr>
             <div id="questionsContainer">
             </div>
             <div>
                 <button type="button" id="${this._addQuestionButtonId}">+ Add Question</button>
-            </div>
+            </div>  
         <hr>
         <button type="submit" class="btn" id="${this._saveQuizButtonId}" style="text-align: center; background-color:#3399ff;">Save</button>
         </form>
@@ -45,6 +44,17 @@ class QuizBuilder {
         if (this.questionsContainerMaxHeight) {
             this._addOverflowStylesToQuestionContainer();
         }
+        this._registerSubmitFromSelect();
+    }
+
+    _registerSubmitFromSelect() {
+        const button = document.getElementById("editQuizButton");
+        const select = document.getElementById("editQuizSelect")
+        console.log(select.value)
+        button.addEventListener("submit", (event) => {
+            event.preventDefault();
+            console.log(select.value);
+        })
     }
 
     _registerFormSubmitListener() {
@@ -81,8 +91,8 @@ class QuizBuilder {
         
     }
     addQuestion() {
-        const newHR = document.createElement("hr")
-        this.questionsContainer.appendChild(newHR);
+        this.newHR = document.createElement("hr");
+        this.questionsContainer.appendChild(this.newHR);
         this._createInputElements()
     }
 
@@ -96,6 +106,7 @@ class QuizBuilder {
     _createInputElements() {
         this.questionsContainer = document.getElementById("questionsContainer");
 
+        const removeQuestionButton = document.createElement("button");
         const questionText = document.createElement("input");
         const choices = document.createElement("input");
         const answer = document.createElement("input");
@@ -111,6 +122,7 @@ class QuizBuilder {
         const choicesHeader = document.createElement("text");
         const answerHeader = document.createElement("text");
 
+        this.questionsContainer.appendChild(removeQuestionButton);
         this.questionsContainer.appendChild(questionTextHeader);
         this.questionsContainer.appendChild(questionText);
         this.questionsContainer.appendChild(choicesHeader);
@@ -119,6 +131,25 @@ class QuizBuilder {
         this.questionsContainer.appendChild(answer);
         this.questionsContainer.appendChild(error);
 
+
+        // Shows removeQuestionButton 
+        removeQuestionButton.textContent = "Remove Questions";
+        removeQuestionButton.className = "removeQuestionButton";
+        choicesHeader.style.display = "inline-block";
+
+        removeQuestionButton.addEventListener("click", (event) => {
+            event.preventDefault();
+            removeQuestionButton.remove();
+            questionTextHeader.remove();
+            questionText.remove();
+            choicesHeader.remove();
+            choices.remove();
+            answerHeader.remove();
+            answer.remove();
+            error.remove();
+            this.newHR.remove();
+        })
+        
         questionTextHeader.textContent = "Type in a question:";
         choicesHeader.textContent = "Type in the choices (comma separated): ";
         answerHeader.textContent = "Type in an answer:";

--- a/Day-11-Quiz-App/quizBuilder.js
+++ b/Day-11-Quiz-App/quizBuilder.js
@@ -62,7 +62,6 @@ class QuizBuilder {
     }
 
     save() {
-        // TODO: implement guard that prevents saving if not all questions are valid.
         if (this.allQuestionsAreValid) { 
             const questions = this._getQuestionsArrayFromInputValues();
             const quizTitle = document.getElementById('quizTitle').value;
@@ -70,8 +69,14 @@ class QuizBuilder {
                 title: quizTitle,
                 questions,
             };
-            console.log(quiz);
-            alert("success");
+            const existingQuizzesString = localStorage.getItem('SidneyQuiz:custom');
+            if (existingQuizzesString) {
+                const existingQuizzes = JSON.parse(existingQuizzesString);
+                localStorage.setItem('SidneyQuiz:custom', JSON.stringify(existingQuizzes.concat(quiz)));
+            } else {
+                localStorage.setItem('SidneyQuiz:custom', JSON.stringify([quiz]));
+            }
+            this.quit()
         }
         
     }

--- a/Day-11-Quiz-App/quizBuilder.js
+++ b/Day-11-Quiz-App/quizBuilder.js
@@ -56,11 +56,11 @@ class QuizBuilder {
 
     _registerSubmitFromSelect() {
         const button = document.getElementById("editQuizButton");
-        const select = document.getElementById("editQuizSelect")
-        console.log(select.value)
+        this.editQuizSelect = document.getElementById("editQuizSelect")
+        console.log(editQuizSelect.value)
         button.addEventListener("submit", (event) => {
             event.preventDefault();
-            console.log(select.value);
+            console.log(editQuizSelect.value);
         })
     }
 
@@ -104,6 +104,7 @@ class QuizBuilder {
     }
 
     quit() {
+        const removeSelectOptions = this.editQuizSelect.options.length = 0;
         this.containerElement.classList.remove("quizBuilderContainer");
         this.containerElement.textContent = '';
         const quitEvent = new Event("QuizBuilder:quit");
@@ -192,6 +193,7 @@ class QuizBuilder {
                 this.allQuestionsAreValid = false;
                 this.saveButton.disabled = true;
                 answerElement.style.borderColor = "red";
+                answerElement.style.borderRadius = "5px"
             }
         }
         answerElement.addEventListener('input', validateAnswer);

--- a/Day-11-Quiz-App/quizBuilderCSS.css
+++ b/Day-11-Quiz-App/quizBuilderCSS.css
@@ -1,5 +1,7 @@
+.quiz-box {
+    width: 600px;
+}
 .quizBuilderContainer {
-    max-width: 600px;
     padding: 0 20px 20px 20px;
     background-color: #eee;
     border: 3px solid rgb(1, 22, 209);

--- a/Day-11-Quiz-App/quizBuilderCSS.css
+++ b/Day-11-Quiz-App/quizBuilderCSS.css
@@ -1,5 +1,5 @@
 .quizBuilderContainer {
-    width: 600px;
+    max-width: 600px;
     padding: 0 20px 20px 20px;
     background-color: #eee;
     border: 3px solid rgb(1, 22, 209);

--- a/Day-11-Quiz-App/quizBuilderCSS.css
+++ b/Day-11-Quiz-App/quizBuilderCSS.css
@@ -84,6 +84,15 @@
     outline: none;
 }
 
+.removeQuestionButton {
+    display: inline;
+    background-color: red;
+    border-radius: 5px;
+    float: right;
+    color: white;
+
+}
+
 .error {
     display: none;
     color: red;

--- a/Day-11-Quiz-App/quizBuilderCSS.css
+++ b/Day-11-Quiz-App/quizBuilderCSS.css
@@ -69,16 +69,3 @@
     font-size: 1.5rem;
     margin-bottom: 8px;
 }
-
-.removeQuestionButton:first-child {
-    display: none;
-} 
-
-.removeQuestionButton {
-    display: inline;
-    background-color: red;
-    border-radius: 5px;
-    float: right;
-    color: white;
-
-}

--- a/Day-11-Quiz-App/quizBuilderCSS.css
+++ b/Day-11-Quiz-App/quizBuilderCSS.css
@@ -56,9 +56,32 @@
     color: #fff;
     padding: 10px 0;
     width: 50%;
-    margin: 8px 0 8px 0;
     border-radius: 3px;
     border: none;
+}
+
+.customQuizButton {
+    text-align: center
+}
+
+#editQuizSelect {
+    width: 89%;
+}
+
+#editQuizButton {
+    width: 10%;
+    float: right;
+}
+
+.editQuiz {
+    background-color: #ddd;
+    font-size: 1.8rem;
+    color: black;
+    border: 1px solid #3399ff;
+    border-radius: 5px;
+    margin: 7px 0;
+    padding: 1rem;
+    outline: none;
 }
 
 .error {

--- a/Day-11-Quiz-App/quizBuilderCSS.css
+++ b/Day-11-Quiz-App/quizBuilderCSS.css
@@ -73,3 +73,12 @@
 .removeQuestionButton:first-child {
     display: none;
 } 
+
+.removeQuestionButton {
+    display: inline;
+    background-color: red;
+    border-radius: 5px;
+    float: right;
+    color: white;
+
+}

--- a/Day-11-Quiz-App/quizBuilderCSS.css
+++ b/Day-11-Quiz-App/quizBuilderCSS.css
@@ -62,46 +62,6 @@
     border: none;
 }
 
-.customQuizButton {
-    text-align: center
-}
-
-#editQuizSelect {
-    width: 78%;
-}
-
-#editQuizButton {
-    width: 10%;
-    cursor: pointer;
-}
-
-#deleteQuizButton {
-    padding-left: 7px;
-    width: 11%;
-    cursor: pointer;
-    background-color: red;
-    border-color: red;
-}
-
-.editQuiz {
-    background-color: #ddd;
-    font-size: 1.8rem;
-    color: black;
-    border: 1px solid #3399ff;
-    border-radius: 5px;
-    margin: 7px 0;
-    padding: 1rem;
-    outline: none;
-}
-
-.removeQuestionButton {
-    display: inline;
-    background-color: red;
-    border-radius: 5px;
-    float: right;
-    color: white;
-
-}
 
 .error {
     display: none;

--- a/Day-11-Quiz-App/quizBuilderCSS.css
+++ b/Day-11-Quiz-App/quizBuilderCSS.css
@@ -99,3 +99,7 @@
     font-size: 1.5rem;
     margin-bottom: 8px;
 }
+
+.removeQuestionButton:first-child {
+    display: none;
+} 

--- a/Day-11-Quiz-App/quizBuilderCSS.css
+++ b/Day-11-Quiz-App/quizBuilderCSS.css
@@ -76,6 +76,7 @@
 }
 
 #deleteQuizButton {
+    padding-left: 7px;
     width: 11%;
     cursor: pointer;
     background-color: red;

--- a/Day-11-Quiz-App/quizBuilderCSS.css
+++ b/Day-11-Quiz-App/quizBuilderCSS.css
@@ -65,12 +65,19 @@
 }
 
 #editQuizSelect {
-    width: 89%;
+    width: 78%;
 }
 
 #editQuizButton {
     width: 10%;
-    float: right;
+    cursor: pointer;
+}
+
+#deleteQuizButton {
+    width: 11%;
+    cursor: pointer;
+    background-color: red;
+    border-color: red;
 }
 
 .editQuiz {

--- a/Day-11-Quiz-App/quizFramework.css
+++ b/Day-11-Quiz-App/quizFramework.css
@@ -1,7 +1,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap');
 
 .sidneyQuizContainer {
-    width: 600px;
+    max-width: 600px;
     padding: 20px;
     padding: 0 20px 20px 20px;
     background-color: #eee;

--- a/Day-11-Quiz-App/quizFramework.css
+++ b/Day-11-Quiz-App/quizFramework.css
@@ -49,6 +49,7 @@
     border: 1px solid #777;
     border-width: 1px 0;
     padding: 5px 0;
+    margin-top: 0px;
 }
 
 .btn {

--- a/Day-11-Quiz-App/styles.css
+++ b/Day-11-Quiz-App/styles.css
@@ -38,3 +38,43 @@ p {
     font-size: 1.25rem;
     color: blue;
 }
+
+.removeQuestionButton {
+    display: inline;
+    background-color: red;
+    border-radius: 5px;
+    float: right;
+    color: white;
+
+}
+
+.editQuiz {
+    background-color: #ddd;
+    font-size: 1.8rem;
+    color: black;
+    border: 1px solid #3399ff;
+    border-radius: 5px;
+    margin: 7px 0;
+    padding: 1rem;
+    outline: none;
+}
+#deleteQuizButton {
+    padding-left: 7px;
+    width: 11%;
+    cursor: pointer;
+    background-color: red;
+    border-color: red;
+}
+
+.customQuizButton {
+    text-align: center
+}
+
+#editQuizSelect {
+    width: 78%;
+}
+
+#editQuizButton {
+    width: 10%;
+    cursor: pointer;
+}

--- a/Day-11-Quiz-App/styles.css
+++ b/Day-11-Quiz-App/styles.css
@@ -39,15 +39,6 @@ p {
     color: blue;
 }
 
-.removeQuestionButton {
-    display: inline;
-    background-color: red;
-    border-radius: 5px;
-    float: right;
-    color: white;
-
-}
-
 .editQuiz {
     background-color: #ddd;
     font-size: 1.8rem;


### PR DESCRIPTION
Instructions from[ list of exercises](https://leanix.atlassian.net/wiki/spaces/THRUST/pages/7473692740/QuizApp+Exercises) on confluence:

## About saving custom quizzes

Store the created quizzes in localstorage ([Link to MDN docs](https://developer.mozilla.org/de/docs/Web/API/Window/localStorage), [Link to introduction page with example](https://javascript.info/localstorage)s) under the key SidneyQuiz:custom with the following JSON string (containing an array of objects):

```Javascript
[
   {
      name: "Harry Potter Trivia",
      questions: [{ text: "Who is Voldemort?", choices: ["dark lord", "mail man"], answer: "mail man"}]
   },
   {
      name: "Pokemon Trivia",
      questions: [{ text: "Who is Pikachu?", choices: ["rat", "dont know"], answer: "dont know"}]
   }
]
```
On your main page that today shows the “Start sport quiz” and “Start HTML quiz” buttons, add another heading “Custom quizzes” below it and add a button “Create custom quiz”.

When this button is clicked, create a new instance of your QuizBuilder class using the same element ID as you would for the normal quizzes.

The QuizBuilder should dispatch two custom DOM events `QuizBuilder:save` and `QuizBuilder:cancel`.

Inside your index.html, react to the `QuizBuilder.save` event using `addEventListener` and get the updated list of custom quizzes using `localStorage.getItem('SidneyQuiz:custom')`. This is where your `QuizBuilder` class saves the data about custom quizzes to (described above).

Then loop over the array of quizzes from the `localStorage` item (after parsing it using `JSON.parse`) and create Button elements below the “Custom quizzes” header for each custom Quiz.

Each button should implement an `addEventListener('click', () => ...)` which works just like the existing ones you have for the Sports and HTML quiz, but will use the quiz title and questions from the custom quiz element of your loop iteration.

When the user presses the “Save” button in the QuizBuilder you should first get the existing custom quizzes using localStorage.getItem('SidneyQuiz:custom'), parse that into a JavaScript array, push your new quiz object into that array and update the localStorage using localStroage.setItem('SidneyQuiz:custom', JSON.stringify(updatedQuizList)).

Afterwards you emit the QuizBuilder:save event as described above. The event should contain the quiz object of the quiz that was just created, not the full list. You will not use this event value as part of this exercise but it makes sense to expose this in general (someone might have a use for it).

## About editing existing quizzes

Exercise 4: Enable editing of existing custom quizzes
Once you have the form for creating custom quizzes, making them editable is a logical next step and won’t be too much work either :slight_smile: 

Initial idea: Below the “Create custom quiz” button provide a HTML select for choosing the quiz to edit and display an “Edit quiz” button next to that select. Pressing this button will jump to the `QuizBuilder` that now not only receives the element ID to replace the innerHTML of as `constructor` parameter but also a `quizDataToEdit` parameter, which will be used to create all necessary HTML inputs and prefill them with the current values. WARNING: the quiz title needs to be read only (in HTML: disabled) as this is right now the only way for us to identify which quiz we are editing.

Once the user saves the quiz again, we don’t add a new object to the `localStorage.getItem('SidneyQuiz:custom')`, but we replace questions inside the object that matches the title of the quiz that is being edited.

